### PR TITLE
Refactor update endpoints

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -9,8 +9,10 @@ from app.services.emag_full_seq import (
     fetch_all_fitness1_products,
     run_create_process,
     run_update_hungarian_process,
+    run_update_price_process,
     run_update_process,
     run_update_romania_process,
+    run_update_status_process,
 )
 from app.services import const
 from app.services import util
@@ -79,6 +81,102 @@ def api_update():
             update_job_status["last_message"] = "Update process started."
 
             summary = run_update_process(pause=pause, batch_size=batch_size)
+
+            update_job_status["running"] = False
+            update_job_status["last_message"] = (
+                f"Update completed. {summary['updated_entries']} entries updated."
+            )
+            add_log(f"Background update finished. Summary: {summary}")
+
+        except Exception as e:
+            update_job_status["running"] = False
+            update_job_status["last_message"] = f"Update failed: {str(e)}"
+            add_log(f"Error during background update: {str(e)}")
+
+    try:
+        thread = threading.Thread(target=background_update)
+        thread.start()
+
+        return (
+            jsonify(
+                {
+                    "status": "success",
+                    "message": "Update process started in background.",
+                }
+            ),
+            202,
+        )
+    except Exception as e:
+        add_log(f"Error launching background update: {str(e)}")
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+@api_bp.route("/update-status", methods=["POST"])
+def api_update_status_only():
+    """Starts the product status update process in a background thread."""
+    global update_job_status
+
+    data = request.get_json() or {}
+    pause = data.get("pause", 1)
+    batch_size = data.get("batch_size", 50)
+
+    add_log("API /update-status endpoint called.")
+
+    def background_update():
+        global update_job_status
+        try:
+            update_job_status["running"] = True
+            update_job_status["last_message"] = "Update process started."
+
+            summary = run_update_status_process(pause=pause, batch_size=batch_size)
+
+            update_job_status["running"] = False
+            update_job_status["last_message"] = (
+                f"Update completed. {summary['updated_entries']} entries updated."
+            )
+            add_log(f"Background update finished. Summary: {summary}")
+
+        except Exception as e:
+            update_job_status["running"] = False
+            update_job_status["last_message"] = f"Update failed: {str(e)}"
+            add_log(f"Error during background update: {str(e)}")
+
+    try:
+        thread = threading.Thread(target=background_update)
+        thread.start()
+
+        return (
+            jsonify(
+                {
+                    "status": "success",
+                    "message": "Update process started in background.",
+                }
+            ),
+            202,
+        )
+    except Exception as e:
+        add_log(f"Error launching background update: {str(e)}")
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+@api_bp.route("/update-price", methods=["POST"])
+def api_update_price_only():
+    """Starts the product price update process in a background thread."""
+    global update_job_status
+
+    data = request.get_json() or {}
+    pause = data.get("pause", 1)
+    batch_size = data.get("batch_size", 50)
+
+    add_log("API /update-price endpoint called.")
+
+    def background_update():
+        global update_job_status
+        try:
+            update_job_status["running"] = True
+            update_job_status["last_message"] = "Update process started."
+
+            summary = run_update_price_process(pause=pause, batch_size=batch_size)
 
             update_job_status["running"] = False
             update_job_status["last_message"] = (

--- a/app/api.py
+++ b/app/api.py
@@ -13,6 +13,7 @@ from app.services.emag_full_seq import (
     run_update_process,
     run_update_romania_process,
     run_update_status_process,
+    run_update_combined_process,
 )
 from app.services import const
 from app.services import util
@@ -177,6 +178,54 @@ def api_update_price_only():
             update_job_status["last_message"] = "Update process started."
 
             summary = run_update_price_process(pause=pause, batch_size=batch_size)
+
+            update_job_status["running"] = False
+            update_job_status["last_message"] = (
+                f"Update completed. {summary['updated_entries']} entries updated."
+            )
+            add_log(f"Background update finished. Summary: {summary}")
+
+        except Exception as e:
+            update_job_status["running"] = False
+            update_job_status["last_message"] = f"Update failed: {str(e)}"
+            add_log(f"Error during background update: {str(e)}")
+
+    try:
+        thread = threading.Thread(target=background_update)
+        thread.start()
+
+        return (
+            jsonify(
+                {
+                    "status": "success",
+                    "message": "Update process started in background.",
+                }
+            ),
+            202,
+        )
+    except Exception as e:
+        add_log(f"Error launching background update: {str(e)}")
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+@api_bp.route("/update-both", methods=["POST"])
+def api_update_both():
+    """Starts the combined price and status update process."""
+    global update_job_status
+
+    data = request.get_json() or {}
+    pause = data.get("pause", 1)
+    batch_size = data.get("batch_size", 50)
+
+    add_log("API /update-both endpoint called.")
+
+    def background_update():
+        global update_job_status
+        try:
+            update_job_status["running"] = True
+            update_job_status["last_message"] = "Update process started."
+
+            summary = run_update_combined_process(pause=pause, batch_size=batch_size)
 
             update_job_status["running"] = False
             update_job_status["last_message"] = (

--- a/app/services/emag_full_seq.py
+++ b/app/services/emag_full_seq.py
@@ -671,6 +671,20 @@ def run_update_price_process(pause=1, batch_size=50, emag_url_ext="bg"):
     return _run_update_process(build_entry, pause, batch_size, emag_url_ext)
 
 
+def run_update_combined_process(pause=1, batch_size=50, emag_url_ext="bg"):
+    """Update both price and status for products."""
+
+    def build_entry(emag_product, fitness1_product):
+        return {
+            "id": emag_product["id"],
+            "sale_price": fitness1_product["regular_price"],
+            "status": fitness1_product["available"],
+            "vat_id": 6,
+        }
+
+    return _run_update_process(build_entry, pause, batch_size, emag_url_ext)
+
+
 def run_update_romania_process(pause=1, batch_size=50, emag_url_ext="ro"):
     """
     Optimized version of the update process with streaming.

--- a/app/services/emag_full_seq.py
+++ b/app/services/emag_full_seq.py
@@ -492,17 +492,14 @@ def run_create_process(pause=1, batch_size=50, emag_url_ext="bg"):
     }
 
 
-def run_update_process(pause=1, batch_size=50, emag_url_ext="bg"):
-    """
-    Optimized version of the update process with streaming.
-    """
+def _run_update_process(build_entry_func, pause=1, batch_size=50, emag_url_ext="bg"):
+    """Generic update process used by price and status updates."""
     process = psutil.Process(os.getpid())
     mem_before = process.memory_info().rss
     cpu_before = process.cpu_times().user
 
     add_log("Starting product update process...")
 
-    # Step 1: Fetch all Fitness1 products once
     fitness1_products = fetch_all_fitness1_products(
         api_url=const.FITNESS1_API_URL, api_key=const.FITNESS1_API_KEY
     )
@@ -512,18 +509,15 @@ def run_update_process(pause=1, batch_size=50, emag_url_ext="bg"):
 
     add_log(f"Fetched {len(fitness1_products)} Fitness1 products.")
 
-    # Create a lookup table for Fitness1 products by barcode
     fitness1_index = {product["barcode"]: product for product in fitness1_products}
 
-    # Step 2: Stream EMAG products page by page
     page = 1
-    items_per_page = 100  # or whatever you want
+    items_per_page = 100
     total_emag_products = 0
     total_updates = 0
     failed_batches = []
 
     while True:
-        # Fetch one page of EMAG products
         payload = {"currentPage": page, "itemsPerPage": items_per_page}
         response = requests.post(
             url=util.build_url(
@@ -557,31 +551,22 @@ def run_update_process(pause=1, batch_size=50, emag_url_ext="bg"):
         total_emag_products += len(emag_products)
         add_log(f"Fetched {len(emag_products)} EMAG products on page {page}.")
 
-        # Map EMAG products to Fitness1 products
         update_batch = []
         for emag_product in emag_products:
             ean_list = emag_product.get("ean", [])
             if not ean_list:
-                continue  # skip products without EAN
+                continue
 
             barcode = ean_list[0]
             fitness1_product = fitness1_index.get(barcode)
 
             if fitness1_product:
-                # Build update entry
-                update_batch.append(
-                    {
-                        "id": emag_product["id"],
-                        "sale_price": fitness1_product["regular_price"],
-                        "status": fitness1_product["available"],
-                        "vat_id": 6,
-                    }
-                )
+                entry = build_entry_func(emag_product, fitness1_product)
+                if entry:
+                    update_batch.append(entry)
 
-        # Split into smaller batches
         batched_updates = util.split_list(update_batch, batch_size)
 
-        # Send each batch
         for i, batch in enumerate(batched_updates):
             if not batch:
                 continue
@@ -629,7 +614,7 @@ def run_update_process(pause=1, batch_size=50, emag_url_ext="bg"):
             else:
                 total_updates += len(batch)
 
-        page += 1  # go to next page
+        page += 1
 
     add_log(
         f"Update process completed: {total_updates} successful updates, {len(failed_batches)} failed batches."
@@ -645,6 +630,45 @@ def run_update_process(pause=1, batch_size=50, emag_url_ext="bg"):
         "updated_entries": total_updates,
         "failed_updates": failed_batches,
     }
+
+
+def run_update_process(pause=1, batch_size=50, emag_url_ext="bg"):
+    """Update both price and status for products."""
+
+    def build_entry(emag_product, fitness1_product):
+        return {
+            "id": emag_product["id"],
+            "sale_price": fitness1_product["regular_price"],
+            "status": fitness1_product["available"],
+            "vat_id": 6,
+        }
+
+    return _run_update_process(build_entry, pause, batch_size, emag_url_ext)
+
+
+def run_update_status_process(pause=1, batch_size=50, emag_url_ext="bg"):
+    """Update only the status field for products."""
+
+    def build_entry(emag_product, fitness1_product):
+        return {
+            "id": emag_product["id"],
+            "status": fitness1_product["available"],
+        }
+
+    return _run_update_process(build_entry, pause, batch_size, emag_url_ext)
+
+
+def run_update_price_process(pause=1, batch_size=50, emag_url_ext="bg"):
+    """Update only the price for products."""
+
+    def build_entry(emag_product, fitness1_product):
+        return {
+            "id": emag_product["id"],
+            "sale_price": fitness1_product["regular_price"],
+            "vat_id": 6,
+        }
+
+    return _run_update_process(build_entry, pause, batch_size, emag_url_ext)
 
 
 def run_update_romania_process(pause=1, batch_size=50, emag_url_ext="ro"):

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -213,6 +213,28 @@
       });
     });
 
+    // Update both status and prices
+    document.getElementById('updateBothBtn').addEventListener('click', function() {
+      showSpinner(true);
+      showAlert('Starting update...', 'info');
+
+      fetch('/api/update-both', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ pause: 1, batch_size: 50 })
+      })
+      .then(response => response.json())
+      .then(data => {
+          console.log('Update started:', data);
+          updateStatusInterval = setInterval(checkUpdateStatus, 5000);
+      })
+      .catch(error => {
+          showSpinner(false);
+          showAlert('Error starting update: ' + error, 'danger');
+          console.error('Error starting update:', error);
+      });
+    });
+
     // When you click the "Update" button, start polling
     document.getElementById('updateRomaniaBtn').addEventListener('click', function() {
       showSpinner(true);

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -169,12 +169,34 @@
     //   });
     // });
 
-    // When you click the "Update" button, start polling
-    document.getElementById('updateBtn').addEventListener('click', function() {
+    // Update only status
+    document.getElementById('updateStatusBtn').addEventListener('click', function() {
       showSpinner(true);
       showAlert('Starting update...', 'info');
 
-      fetch('/api/update', {
+      fetch('/api/update-status', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ pause: 1, batch_size: 50 })
+      })
+      .then(response => response.json())
+      .then(data => {
+          console.log('Update started:', data);
+          updateStatusInterval = setInterval(checkUpdateStatus, 5000);
+      })
+      .catch(error => {
+          showSpinner(false);
+          showAlert('Error starting update: ' + error, 'danger');
+          console.error('Error starting update:', error);
+      });
+    });
+
+    // Update only prices
+    document.getElementById('updatePriceBtn').addEventListener('click', function() {
+      showSpinner(true);
+      showAlert('Starting update...', 'info');
+
+      fetch('/api/update-price', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ pause: 1, batch_size: 50 })

--- a/app/templates/partials/_operations.html
+++ b/app/templates/partials/_operations.html
@@ -3,10 +3,15 @@
       Operations
     </div>
     <div class="card-body">
+      <div class="mb-3">
+        <h5>Update Bulgaria Products</h5>
+        <div class="btn-group mb-2" role="group" aria-label="Update Bulgaria Products">
+          <button id="updateStatusBtn" class="btn btn-success">Update Status</button>
+          <button id="updatePriceBtn" class="btn btn-success">Update Prices</button>
+          <button id="updateBothBtn" class="btn btn-success">Update All</button>
+        </div>
+      </div>
       <div class="d-flex flex-wrap mb-3">
-        <!-- <button id="createBtn" class="btn btn-primary me-2">Create Products</button> -->
-        <button id="updateStatusBtn" class="btn btn-success me-2">Update Status</button>
-        <button id="updatePriceBtn" class="btn btn-success me-2">Update Prices</button>
         <button id="deleteLogsBtn" class="btn btn-danger me-2">Delete Logs</button>
         <button id="updateRomaniaBtn" class="btn btn-success me-2">Update Romania Products</button>
         <button id="updateHungaryBtn" class="btn btn-success me-2">Update Hungary Products</button>

--- a/app/templates/partials/_operations.html
+++ b/app/templates/partials/_operations.html
@@ -5,7 +5,8 @@
     <div class="card-body">
       <div class="d-flex flex-wrap mb-3">
         <!-- <button id="createBtn" class="btn btn-primary me-2">Create Products</button> -->
-        <button id="updateBtn" class="btn btn-success me-2">Update Products</button>
+        <button id="updateStatusBtn" class="btn btn-success me-2">Update Status</button>
+        <button id="updatePriceBtn" class="btn btn-success me-2">Update Prices</button>
         <button id="deleteLogsBtn" class="btn btn-danger me-2">Delete Logs</button>
         <button id="updateRomaniaBtn" class="btn btn-success me-2">Update Romania Products</button>
         <button id="updateHungaryBtn" class="btn btn-success me-2">Update Hungary Products</button>


### PR DESCRIPTION
## Summary
- add generic `_run_update_process` and split into `run_update_status_process` and `run_update_price_process`
- expose `/api/update-status` and `/api/update-price` endpoints
- update dashboard to call new endpoints
- separate Update Products button into Update Status and Update Prices

## Testing
- `ruff check --quiet`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863e104fae48323a197907d2d1d8424